### PR TITLE
Make DNS configuration optional

### DIFF
--- a/pot/src/lib.rs
+++ b/pot/src/lib.rs
@@ -17,6 +17,12 @@ use walkdir::WalkDir;
 pub type Result<T> = ::std::result::Result<T, error::PotError>;
 
 #[derive(Debug, Clone)]
+pub struct PotDnsConfig {
+    pub pot_name: String,
+    pub ip: IpAddr,
+}
+
+#[derive(Debug, Clone)]
 pub struct PotSystemConfig {
     pub zfs_root: String,
     pub fs_root: String,
@@ -24,8 +30,7 @@ pub struct PotSystemConfig {
     pub netmask: IpAddr,
     pub gateway: IpAddr,
     pub ext_if: String,
-    pub dns_name: String,
-    pub dns_ip: IpAddr,
+    pub dns: Option<PotDnsConfig>,
 }
 
 impl Default for PotSystemConfig {
@@ -38,8 +43,7 @@ impl Default for PotSystemConfig {
             netmask: IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0)),
             gateway: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             ext_if: String::default(),
-            dns_name: String::default(),
-            dns_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dns: None,
         }
     }
 }
@@ -63,8 +67,10 @@ impl TryFrom<system::PartialSystemConf> for PotSystemConfig {
                 netmask: psc.netmask.unwrap(),
                 gateway: psc.gateway.unwrap(),
                 ext_if: psc.ext_if.unwrap(),
-                dns_name: psc.dns_name.unwrap(),
-                dns_ip: psc.dns_ip.unwrap(),
+                dns: match psc.dns_ip {
+                  Some(ip) => Some(PotDnsConfig{pot_name: psc.dns_name.unwrap(), ip}),
+                  None => None
+                },
             })
         } else {
             Err(error::PotError::IncompleteSystemConf)

--- a/pot/src/system.rs
+++ b/pot/src/system.rs
@@ -32,7 +32,16 @@ impl PartialSystemConf {
             Err(_) => return dconf,
         };
         let pconf = PartialSystemConf::from_str(&s).ok().unwrap_or_default();
+        let pconf_has_dns_ip = pconf.dns_ip != None;
         dconf.merge(pconf);
+        // remove dns_ip if it came from default config and is not inside pot network
+        if !pconf_has_dns_ip {
+            if let Some(dns_ip) = &dconf.dns_ip {
+                if !dconf.network.unwrap().contains(dns_ip) {
+                    dconf.dns_ip = None;
+                }
+            }
+        }
         dconf
     }
 
@@ -44,7 +53,7 @@ impl PartialSystemConf {
             && self.gateway.is_some()
             && self.ext_if.is_some()
             && self.dns_name.is_some()
-            && self.dns_ip.is_some()
+            && (self.dns_ip.is_none() || self.dns_name.is_some())
     }
 
     fn merge(&mut self, rhs: PartialSystemConf) {


### PR DESCRIPTION
If DNS IP is set, DNS name must also be set.

In case DNS IP is set in pot.default.conf and it is not matching the network, treat it like unset.

This should avoid breakage/annoyance with new setups while it should be backwards compatible, so it won't break existing setups.

Addresses https://github.com/bsdpot/pot/issues/264